### PR TITLE
#14 BrowserStack credentials can be now passed to test via cmd argument

### DIFF
--- a/salsa_webqa/library/support/browserstack.py
+++ b/salsa_webqa/library/support/browserstack.py
@@ -13,7 +13,7 @@ class BrowserStackAPI():
         pass
 
     def get_projects(self, auth):
-        url = "https://browserstack.com/automate/projects.json"
+        url = "https://www.browserstack.com/automate/projects.json"
         r = requests.get(url, auth=auth)
         json_res = json.loads(r.text)
         return json_res
@@ -34,7 +34,7 @@ class BrowserStackAPI():
         return project
 
     def get_builds(self, auth):
-        url = "https://browserstack.com/automate/builds.json"
+        url = "https://www.browserstack.com/automate/builds.json"
         r = requests.get(url, auth=auth)
         json_res = json.loads(r.text)
         return json_res
@@ -51,7 +51,7 @@ class BrowserStackAPI():
 
     def get_sessions(self, auth, build_name):
         hashed_id = self.get_build_hash_id(auth, build_name)
-        url = "https://browserstack.com/automate/builds/%s/sessions.json" % hashed_id
+        url = "https://www.browserstack.com/automate/builds/%s/sessions.json" % hashed_id
         r = requests.get(url, auth=auth)
         sessions = json.loads(r.text)
         return sessions

--- a/salsa_webqa/salsa_runner.py
+++ b/salsa_webqa/salsa_runner.py
@@ -53,6 +53,12 @@ class SalsaRunner():
         self.env_type = cmd_args[0]
         self.test_type = cmd_args[1]
 
+        # load browserstack credentials from cmd argument, if available
+        if cmd_args[2] != 'none':
+            browserstack_auth = cmd_args[2].split(':')
+            os.environ['bs_username'] = browserstack_auth[0]
+            os.environ['bs_password'] = browserstack_auth[1]
+
     def set_project_root(self):
         """ Sets tested project root folder into OS environment variable """
         if os.path.exists(self.project_root) and os.path.isdir(self.project_root):
@@ -184,8 +190,11 @@ class SalsaRunner():
         parser.add_argument('--tests',
                             help='Tests to run; options: "smoke", "all" (default)',
                             default='all')
+        parser.add_argument('--browserstack',
+                            help='BrowserStack credentials; format: "username:token"',
+                            default='none')
         args = parser.parse_args()
-        return [args.env, args.tests]
+        return [args.env, args.tests, args.browserstack]
 
     def cleanup_results(self):
         """ Cleans up test result folder """


### PR DESCRIPTION
- format: --browserstack username:password
- any other property can be also passed as environment property now (will be used if not found in both config files)
- related fix: modified obsolete BrowserStackAPI urls
