### PR TITLE
Add suport for generating reports for non selenium project

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ os.environ['BROWSERSTACK'] = '{"test_suite": [{"browser": "Firefox", "browser_ve
 --mobile yes # run tests on mobile browserstack combinations that are stored in "browserstack_mobile.properties" - can't be at the same time with smoke, default value is none
 
 --browserstack testuser1:p84asd21d15asd454 # authenticate on BrowserStack using user "testuser1" and token "p84asd21d15asd454"
+--reporting all # generate reports for selenium and non selenium tests, if you want to run only selenium use value "selenium", for non selenium use "simple"
+
 ```
 
 Combinations yet unsupported by Shishito:
@@ -113,6 +115,9 @@ Combinations yet unsupported by Shishito:
 * `--env direct` together with `--tests smoke`
 
 If no arguments are specified, Shishito, by default, searches for BROWSERSTACK combinations in .properties files and runs all tests
+##Run different tests types (selenium and non selenium)
+* to do this use command line parameter: --reporting, default option is "all", other options are "selenium" and "simple"
+* to run non selenium tests with runner: create folder "non_selenium_tests" and put there tests and conftest.py files, if project contain only non selenium tests, then in command line parameter provide --reporting simple
 
 ## Configuration
 

--- a/salsa_webqa/library/control_test.py
+++ b/salsa_webqa/library/control_test.py
@@ -52,9 +52,6 @@ class ControlTest():
         config_path = os.path.join(self.project_root, 'config')
         #return_configs = []
         config = ConfigParser.ConfigParser()
-        '''
-        if not os.path.exists(config_path):
-            return None'''
         if os.path.exists(config_path):
             # load server config variables
             server_config = os.path.join(config_path, 'server_config.properties')

--- a/salsa_webqa/library/control_test.py
+++ b/salsa_webqa/library/control_test.py
@@ -47,7 +47,7 @@ class ControlTest():
         return project_root
 
     def load_configs(self):
-        """ Loads variables from .properties configuration files,  check in project didn't contain such folder
+        """ Loads variables from .properties configuration files,  check if project didn't contain such folder
         (for non selenium projects) """
         config_path = os.path.join(self.project_root, 'config')
         if not os.path.exists(config_path):
@@ -161,7 +161,7 @@ class ControlTest():
     def get_test_name(self):
         """ Returns test name from the call stack, assuming there can be only
          one 'test_' file in the stack. If there are more it means two PyTest
-        non_selenium_tests ran when calling get_test_name, which is invalid use case. """
+        tests ran when calling get_test_name, which is invalid use case. """
         test_name = None
         frames = inspect.getouterframes(inspect.currentframe())
         for frame in frames:

--- a/salsa_webqa/library/control_test.py
+++ b/salsa_webqa/library/control_test.py
@@ -50,19 +50,28 @@ class ControlTest():
         """ Loads variables from .properties configuration files,  check if project didn't contain such folder
         (for non selenium projects) """
         config_path = os.path.join(self.project_root, 'config')
-        if not os.path.exists(config_path):
-            return None
+        #return_configs = []
         config = ConfigParser.ConfigParser()
-        # load server config variables
-        server_config = os.path.join(config_path, 'server_config.properties')
-        config.read(server_config)
-        server_config_vars = dict(config.defaults())
-        # load local config variables
-        local_config = os.path.join(config_path, 'local_config.properties')
-        config.read(local_config)
-        local_config_vars = dict(config.defaults())
-        return_configs = [server_config_vars, local_config_vars]
-        return return_configs
+        '''
+        if not os.path.exists(config_path):
+            return None'''
+        if os.path.exists(config_path):
+            # load server config variables
+            server_config = os.path.join(config_path, 'server_config.properties')
+            config.read(server_config)
+            server_config_vars = dict(config.defaults())
+            # load local config variables
+            local_config = os.path.join(config_path, 'local_config.properties')
+            config.read(local_config)
+            local_config_vars = dict(config.defaults())
+            # load non selenium config variables
+            non_selenium_config = os.path.join(config_path, 'non_selenium_config.properties')
+            config.read(non_selenium_config)
+            non_selenium_config = dict(config.defaults())
+            return_configs = [server_config_vars, local_config_vars, non_selenium_config]
+            return return_configs
+        else:
+            return None
 
     def gid(self, searched_id):
         """ Gets value from config variables based on provided key.
@@ -87,7 +96,7 @@ class ControlTest():
                 else:
                     value_to_return = string_returned
             except:
-                print('There was an error while retrieving value "' + searched_id + '" from local config!.'
+                print('There was an error while retrieving value "' + searched_id + '"from local config!.'
                       + '\nUsing server value instead.')
                 use_server = True
         else:

--- a/salsa_webqa/library/control_test.py
+++ b/salsa_webqa/library/control_test.py
@@ -47,20 +47,20 @@ class ControlTest():
         return project_root
 
     def load_configs(self):
-        """ Loads variables from .properties configuration files """
+        """ Loads variables from .properties configuration files,  check in project didn't contain such folder
+        (for non selenium projects) """
         config_path = os.path.join(self.project_root, 'config')
+        if not os.path.exists(config_path):
+            return None
         config = ConfigParser.ConfigParser()
-
         # load server config variables
         server_config = os.path.join(config_path, 'server_config.properties')
         config.read(server_config)
         server_config_vars = dict(config.defaults())
-
         # load local config variables
         local_config = os.path.join(config_path, 'local_config.properties')
         config.read(local_config)
         local_config_vars = dict(config.defaults())
-
         return_configs = [server_config_vars, local_config_vars]
         return return_configs
 
@@ -69,6 +69,8 @@ class ControlTest():
          If local execution parameter is "True", function will try to search for parameter in local configuration file.
          If such parameter is not found or there is an error while reading the file, server (default) configuration
          file will be used instead. """
+        if self.configs is None:
+            return None
         server_config = self.configs[0]
         local_config = self.configs[1]
         local_execution = local_config.get('local_execution')
@@ -159,7 +161,7 @@ class ControlTest():
     def get_test_name(self):
         """ Returns test name from the call stack, assuming there can be only
          one 'test_' file in the stack. If there are more it means two PyTest
-        tests ran when calling get_test_name, which is invalid use case. """
+        non_selenium_tests ran when calling get_test_name, which is invalid use case. """
         test_name = None
         frames = inspect.getouterframes(inspect.currentframe())
         for frame in frames:

--- a/salsa_webqa/salsa_runner.py
+++ b/salsa_webqa/salsa_runner.py
@@ -63,7 +63,7 @@ class SalsaRunner():
         self.bs_username = credentials['bs_username']
         self.bs_password = credentials['bs_password']
         # check if configuration files are present
-        if self.reporting != "simple":
+        if self.reporting != "simple" and self.driver_name is not None:
             if self.test_mobile == 'yes':
                 if not (os.path.exists(self.bs_config_file_mobile)):
                     sys.exit('Browserstack mobile properties file not found! Session terminated.')
@@ -184,6 +184,10 @@ class SalsaRunner():
     def trigger_pytest(self, config_section):
         """ Runs PyTest runner on specific configuration """
         if config_section is None or self.reporting == 'simple':
+            path = os.path.join(self.project_root, 'non_selenium_tests')
+            if not os.path.exists(path):
+                print("Can't run non selenium tests files are not found")
+                return None
             pytest_arguments = [os.path.join(self.project_root, 'non_selenium_tests')]
             pytest_arguments.append('--junitxml=' + os.path.join(self.result_folder, "Non_selenium_report" + '.xml'))
             pytest_arguments.append('--html=' + os.path.join(self.result_folder, "Non_selenium_report" + '.html'))

--- a/salsa_webqa/salsa_runner.py
+++ b/salsa_webqa/salsa_runner.py
@@ -24,7 +24,7 @@ bs_api = BrowserStackAPI()
 
 class SalsaRunner():
     """ Selenium Webdriver Python test runner.
-    - runs python selenium non_selenium_tests on customizable configurations, locally or on BrowserStack using PyTest
+    - runs python selenium tests on customizable configurations, locally or on BrowserStack using PyTest
     - checks for available BrowserStack sessions and wait if necessary
     - archive the test results in .zip file """
 
@@ -143,7 +143,7 @@ class SalsaRunner():
             return test_status
 
     def run_on_browserstack(self):
-        """ Runs non_selenium_tests on BrowserStack """
+        """ Runs tests on BrowserStack """
         test_status = 0
         # If password not provided in command line look ad server configuration file
         if self.bs_username is None:
@@ -172,12 +172,12 @@ class SalsaRunner():
         return test_status
 
     def run_locally(self):
-        """ Runs non_selenium_tests on local browser """
+        """ Runs tests on local browser """
         print('Running for browser: ' + self.driver_name)
         return self.trigger_pytest(self.driver_name)
 
     def run_non_selenium(self):
-        """ Runs non_selenium_tests on local browser """
+        """ Runs non_selenium_tests"""
         print('Running non selenium tests')
         return self.trigger_pytest(None)
 
@@ -207,10 +207,10 @@ class SalsaRunner():
 
         # setup pytest arguments for browserstack
         if self.driver_name.lower() == 'browserstack':
-            # get arguments for running non_selenium_tests on mobile browsers
+            # get arguments for running tests on mobile browsers
             if self.test_mobile == 'yes':
                 pytest_arguments = self.get_pytest_arguments_mobile(config_section, pytest_arguments)
-            # get arguments for running non_selenium_tests on desktop browsers
+            # get arguments for running tests on desktop browsers
             else:
                 pytest_arguments = self.get_pytest_arguments_desktop(config_section, pytest_arguments)
 
@@ -229,7 +229,7 @@ class SalsaRunner():
         return pytest.main(pytest_arguments)
 
     def get_pytest_arguments_desktop(self, config_section, pytest_arguments):
-        """ get pytest arguments to run non_selenium_tests on browserstack desktop browsers """
+        """ get pytest arguments to run tests on browserstack desktop browsers """
         # arguments passed through environment variable
         if self.env_type == 'direct':
             browser = config_section['browser']
@@ -275,7 +275,7 @@ class SalsaRunner():
         return pytest_arguments
 
     def get_pytest_arguments_mobile(self, config_section, pytest_arguments):
-        """ get pytest arguments to run non_selenium_tests on browserstack mobile browsers """
+        """ get pytest arguments to run tests on browserstack mobile browsers """
         # arguments passed through environment variable
         if self.env_type == 'direct':
             browser_name = config_section['browserName']
@@ -325,7 +325,7 @@ class SalsaRunner():
                             help='Tests to run; options: "smoke", "all" (default)',
                             default='all')
         parser.add_argument('--mobile',
-                            help='Run non_selenium_tests on mobile/tablets, "default:none"'
+                            help='Run tests on mobile/tablets, "default:none"'
                                  'for running use "yes"',
                             default='none')
         parser.add_argument('--jira_support',


### PR DESCRIPTION
Support for using shishito_runner in non selenium project:
* added new command line parameter: --reporting, default option is "all", other options are "selenium" and "simple"
* to run non selenium tests with runner: create folder "non_selenium_tests" and put there tests and conftest.py files, if project contain only non selenium tests, then in command line parameter provide --reporting simple
