### PR TITLE
Adding failure reports to failed test case description #44

### DIFF
--- a/shishito/reporting/reporter.py
+++ b/shishito/reporting/reporter.py
@@ -67,9 +67,15 @@ class Reporter(object):
             root = tree.getroot()
             for child in root:
                 if child.tag == 'testcase':
-                    case['cases'].append({
-                        'name': child.get('name'),
-                        'result': 'failure' if child.findall('failure') else 'success',
-                    })
+                    failure = child.find('failure')
+                    entry = {'name': child.get('name')}
+                    # ET Element object returns bool False, so condition needs to check against None value
+                    if failure is not None:
+                        entry['result'] = 'failure'
+                        entry['failure_message'] = failure.text
+                    else:
+                        entry['result'] = 'success'
+                        entry['failure_message'] = None
+                    case['cases'].append(entry)
             test_cases.append(case)
         return test_cases

--- a/shishito/services/testrail_api.py
+++ b/shishito/services/testrail_api.py
@@ -133,7 +133,11 @@ class TestRail(object):
                 tr_test_id = tr_tests.get(xunit_test['name'])
                 result_id = {'success': 1, 'failure': 5}.get(xunit_test['result'])
                 if tr_test_id and result_id:
-                    test_results.append({'test_id': tr_test_id, 'status_id': result_id})
+                    # Add result content into the payload list
+                    result = {'test_id': tr_test_id, 'status_id': result_id}
+                    if result_id == 5:
+                        result['comment'] = xunit_test['failure_message']
+                    test_results.append(result)
 
             response = self.tr_post('add_results/{}'.format(run_id), {'results': test_results})
             if response.status_code != requests.codes.ok:


### PR DESCRIPTION
Small tweak that adds test failure trace info into test rail test-case descriptions
![failure test](https://cloud.githubusercontent.com/assets/6403413/8156187/1ed62618-134b-11e5-85d2-002f800fc431.png)
