### PR TITLE
Add Debug events processing

### DIFF
--- a/shishito/reporting/junithtml.py
+++ b/shishito/reporting/junithtml.py
@@ -60,7 +60,7 @@ class LogHTML(object):
         sec = dict(report.sections)
         output = ""
         for name in ('out', 'err'):
-            content = sec.get("Captured std%s" % name)
+            content = sec.get("Captured std%s setup" % name)
             if content:
                 output = output + content
         return output
@@ -228,8 +228,9 @@ class LogHTML(object):
         info = output.split(" ")
         links_html = []
         for i in range(0, len(info)):
-            if ("http" in info[i] and "browserstack.com" in info[i]):
-                links_html.append(html.a("link", href=info[i], target='_blank'))
+            match_obj = re.search(r'(https?://www.browserstack.com/automate/builds/[\w]*/sessions/[\w]*)/', info[i])
+            if match_obj:
+                links_html.append(html.a("link", href=match_obj.group(1), target='_blank'))
                 links_html.append(' ')
 
         self.test_logs.append(html.tr([

--- a/shishito/reporting/junithtml.py
+++ b/shishito/reporting/junithtml.py
@@ -196,6 +196,11 @@ class LogHTML(object):
                         else:
                             log.append(raw(cgi.escape(line)))
                     log.append(html.br())
+
+                if len(report.sections) > 2:
+                    for stdline in report.sections[2]:
+                        log.append(stdline)
+
                 if not os.path.exists(self.screenshot_path):
                     os.makedirs(self.screenshot_path)
                 self.append_screenshot(testmethod, log)

--- a/shishito/runtime/environment/browserstack.py
+++ b/shishito/runtime/environment/browserstack.py
@@ -109,7 +109,6 @@ class ControlEnvironment(ShishitoEnvironment):
             'browser_version': get_opt(config_section, 'browser_version'),
             'resolution': get_opt(config_section, 'resolution'),
             'name': self.get_test_name() + time.strftime('_%Y-%m-%d'),
-            'browserstack.local': True,
         }
 
     # TODO will need to implement some edge cases from there (mobile emulation etc..)

--- a/shishito/runtime/environment/browserstack.py
+++ b/shishito/runtime/environment/browserstack.py
@@ -109,6 +109,7 @@ class ControlEnvironment(ShishitoEnvironment):
             'browser_version': get_opt(config_section, 'browser_version'),
             'resolution': get_opt(config_section, 'resolution'),
             'name': self.get_test_name() + time.strftime('_%Y-%m-%d'),
+            'browserstack.local': True,
         }
 
     # TODO will need to implement some edge cases from there (mobile emulation etc..)

--- a/shishito/runtime/environment/shishito.py
+++ b/shishito/runtime/environment/shishito.py
@@ -85,10 +85,14 @@ class ShishitoEnvironment(object):
         if browser_type == 'chrome':
             chrome_options = webdriver.ChromeOptions()
             chrome_options.add_experimental_option("excludeSwitches", ["ignore-certificate-errors"])
+            chrome_options.add_extension('/Users/pavelp/extensions/0.14.9_0.crx')
             capabilities.update(chrome_options.to_capabilities())
         elif browser_type == 'firefox':
             profile = webdriver.FirefoxProfile()
-
+            profile.add_extension("/Users/pavelp/extensions/Firefox/quickjava-2.0.8-fx.xpi")
+            profile.set_preference("thatoneguydotnet.QuickJava.curVersion", "2.0.8.1")  ## Prevents loading the 'thank you for installing screen'
+            profile.set_preference("thatoneguydotnet.QuickJava.startupStatus.Images", 2)  ## Turns images off
+            profile.set_preference("thatoneguydotnet.QuickJava.startupStatus.AnimatedImage", 2)  ## Turns animated images off
         if profile is None:
             return None
 

--- a/shishito/runtime/environment/shishito.py
+++ b/shishito/runtime/environment/shishito.py
@@ -85,14 +85,9 @@ class ShishitoEnvironment(object):
         if browser_type == 'chrome':
             chrome_options = webdriver.ChromeOptions()
             chrome_options.add_experimental_option("excludeSwitches", ["ignore-certificate-errors"])
-            chrome_options.add_extension('/Users/pavelp/extensions/0.14.9_0.crx')
             capabilities.update(chrome_options.to_capabilities())
         elif browser_type == 'firefox':
             profile = webdriver.FirefoxProfile()
-            profile.add_extension("/Users/pavelp/extensions/Firefox/quickjava-2.0.8-fx.xpi")
-            profile.set_preference("thatoneguydotnet.QuickJava.curVersion", "2.0.8.1")  ## Prevents loading the 'thank you for installing screen'
-            profile.set_preference("thatoneguydotnet.QuickJava.startupStatus.Images", 2)  ## Turns images off
-            profile.set_preference("thatoneguydotnet.QuickJava.startupStatus.AnimatedImage", 2)  ## Turns animated images off
         if profile is None:
             return None
 

--- a/shishito/runtime/platform/shishito_control_test.py
+++ b/shishito/runtime/platform/shishito_control_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 
@@ -45,7 +46,7 @@ class ShishitoControlTest(object):
 
         self.driver.quit()
 
-    def stop_test(self, test_info):
+    def stop_test(self, test_info, debug_events=None):
         """ To be executed after every test-case (test function). If test failed, function saves
         screenshots created during test.
 
@@ -54,12 +55,24 @@ class ShishitoControlTest(object):
 
         if test_info.test_status not in ('passed', None):
             # save screenshot in case test fails
+            file_name = re.sub('[^A-Za-z0-9_. ]+', '', test_info.test_name)
+
             screenshot_folder = os.path.join(self.shishito_support.project_root, 'screenshots')
+
             if not os.path.exists(screenshot_folder):
                 os.makedirs(screenshot_folder)
 
-            file_name = re.sub('[^A-Za-z0-9_. ]+', '', test_info.test_name)
             self.driver.save_screenshot(os.path.join(screenshot_folder, file_name + '.png'))
+
+            #Save debug info to file
+            if debug_events is not None:
+                debugevent_folder = os.path.join(self.shishito_support.project_root, 'debug_events')
+
+                if not os.path.exists(debugevent_folder):
+                    os.makedirs(debugevent_folder)
+
+                with open(os.path.join(debugevent_folder, file_name + '.json'), 'w') as logfile:
+                        json.dump(debug_events, logfile)
 
     def test_init(self, url):
         """ Executed only once after browser starts.


### PR DESCRIPTION
Add ability to process events from window.debugEventLog and add them to Log report

Example of use
```
event_log = self.driver.execute_script('return window.debugEventLog') 
self.tc.stop_test(get_test_info(), debug_events=event_log)
```