### PR TITLE
Test rails

### DIFF
--- a/shishito/services/testrail_api.py
+++ b/shishito/services/testrail_api.py
@@ -15,7 +15,7 @@ from shishito.runtime.shishito_support import ShishitoSupport
 class TestRail(object):
     """ TestRail object """
 
-    def __init__(self, user, password, timestamp):
+    def __init__(self, user, password, timestamp, build):
         self.shishito_support = ShishitoSupport()
         self.test_rail_instance = self.shishito_support.get_opt('test_rail_url')
         self.user = user
@@ -26,7 +26,7 @@ class TestRail(object):
         self.project_id = self.shishito_support.get_opt('test_rail_project_id')
         self.section_id = self.shishito_support.get_opt('test_rail_section_id')
         self.test_plan_id = self.shishito_support.get_opt('test_rail_test_plan_id')
-        self.test_plan_name = self.shishito_support.get_opt('test_plan_name') or "All tests"
+        self.test_plan_name = self.shishito_support.get_opt('test_plan_name') or build
         self.suite_id = self.shishito_support.get_opt('test_rail_suite_id')
 
         # shishito results
@@ -39,7 +39,12 @@ class TestRail(object):
     def post_results(self):
         """ Create test-cases on TestRail, adds a new test run and update results for the run """
         self.create_missing_test_cases()
-        test_plan_id = self.add_test_plan()
+
+        if self.test_plan_name:
+            test_plan_id = self.add_test_plan()
+        else:
+            test_plan_id = self.test_plan_id
+
         test_run = self.add_test_run(test_plan_id)
         self.add_test_results(test_run)
 
@@ -115,7 +120,7 @@ class TestRail(object):
             if plan['name'] == self.test_plan_name:
                 return plan['id']
 
-        result = self.tr_post('add_plan/{}'.format(self.project_id),{"name": self.test_plan_name})
+        result = self.tr_post('add_plan/{}'.format(self.project_id), {"name": self.test_plan_name})
 
         return json.loads(result.text)['id']
 

--- a/shishito/services/testrail_api.py
+++ b/shishito/services/testrail_api.py
@@ -26,7 +26,7 @@ class TestRail(object):
         self.project_id = self.shishito_support.get_opt('test_rail_project_id')
         self.section_id = self.shishito_support.get_opt('test_rail_section_id')
         self.test_plan_id = self.shishito_support.get_opt('test_rail_test_plan_id')
-        self.test_plan_name = self.shishito_support.get_opt('test_plan_name') or build
+        self.test_plan_name = self.shishito_support.get_opt('test_rail_test_plan_name') or build
         self.suite_id = self.shishito_support.get_opt('test_rail_suite_id')
 
         # shishito results

--- a/shishito/services/testrail_api.py
+++ b/shishito/services/testrail_api.py
@@ -26,6 +26,7 @@ class TestRail(object):
         self.project_id = self.shishito_support.get_opt('test_rail_project_id')
         self.section_id = self.shishito_support.get_opt('test_rail_section_id')
         self.test_plan_id = self.shishito_support.get_opt('test_rail_test_plan_id')
+        self.test_plan_name = self.shishito_support.get_opt('test_plan_name') or "All tests"
         self.suite_id = self.shishito_support.get_opt('test_rail_suite_id')
 
         # shishito results
@@ -38,7 +39,8 @@ class TestRail(object):
     def post_results(self):
         """ Create test-cases on TestRail, adds a new test run and update results for the run """
         self.create_missing_test_cases()
-        test_run = self.add_test_run()
+        test_plan_id = self.add_test_plan()
+        test_run = self.add_test_run(test_plan_id)
         self.add_test_results(test_run)
 
     def tr_get(self, url):
@@ -60,6 +62,14 @@ class TestRail(object):
         """
         return requests.post(self.uri_base + url, auth=(self.user, self.password), data=json.dumps(payload),
                              headers=self.default_headers)
+
+    def get_all_test_plans(self):
+        """ Gets list of all test-plans from certain project
+
+        :return: list of test-plans (names = strings)
+        """
+        test_plans_list = self.tr_get('get_plans/{}'.format(self.project_id))
+        return [{'name': test_plan['name'], 'id': test_plan['id']} for test_plan in test_plans_list]
 
     def get_all_test_cases(self):
         """ Gets list of all test-cases from certain project
@@ -97,17 +107,30 @@ class TestRail(object):
                         test_case_names.append(item['name'])
         return post_errors
 
-    def add_test_run(self):
+    def add_test_plan(self):
+        test_plan_id = 0
+
+        # Check if already exists
+        for plan in self.get_all_test_plans():
+            if plan['name'] == self.test_plan_name:
+                return plan['id']
+
+        result = self.tr_post('add_plan/{}'.format(self.project_id),{"name": self.test_plan_name})
+
+        return json.loads(result.text)['id']
+
+    def add_test_run(self, test_plan_id = None):
         """ Adds new test run under certain test plan into TestRail
 
         :return: dictionary of TestRail run names & IDs
         """
+        test_plan_id = test_plan_id or self.test_plan_id
         runs_created = []
         # Iterate over results for each environment combination
         for result_combination in self.shishito_results:
             run_name = '{} ({})'.format(result_combination['name'][:-4], self.timestamp)
             test_run = {"case_ids": [case['id'] for case in self.get_all_test_cases()]}
-            result = self.tr_post('add_plan_entry/{}'.format(self.test_plan_id),
+            result = self.tr_post('add_plan_entry/{}'.format(test_plan_id),
                                   {"suite_id": self.suite_id, "name": run_name, "runs": [test_run]}).json()
             # lookup test run id
             for run in result['runs']:

--- a/shishito/shishito_runner.py
+++ b/shishito/shishito_runner.py
@@ -27,6 +27,9 @@ class ShishitoRunner(object):
         # parse cmd  args
         self.cmd_args = self.handle_cmd_args()
 
+        # Get SUT build for use in reporting
+        self.test_build = self.cmd_args['build']
+
         self.reporter = Reporter(project_root, self.test_timestamp)
         self.shishito_support = ShishitoSupport(
             cmd_args=self.cmd_args,
@@ -64,6 +67,8 @@ class ShishitoRunner(object):
                             help='Path to appium application')
         parser.add_argument('--test',
                             help='Run specified test (PyTest string expression)')
+        parser.add_argument('--build',
+                            help='Specify build number for reporting purposes')
         args = parser.parse_args()
 
         # return args dict --> for use in other classes
@@ -101,5 +106,5 @@ class ShishitoRunner(object):
             except (AttributeError, ValueError):
                 raise ValueError('TestRail credentials were not specified! Unable to connect to TestRail.')
 
-            test_rail = TestRail(tr_user, tr_password, self.test_timestamp)
+            test_rail = TestRail(tr_user, tr_password, self.test_timestamp, self.test_build)
             test_rail.post_results()


### PR DESCRIPTION
Ad support for Test Rail's Test Plan name specification:
-as a config property `test_rail_test_plan_name`
-if not specified, uses command line parameter "build"
e.g. 'shi --build=develop/1234' wil create Test PLan with the same name
-if "build" not specified, do not create new Test Plan, but use the `test_plan_id` parameter to identify existing test plan (original behaviour)

Note: If a plan with specified name already exists, the test results are added as a new Test Run to that plan