### PR TITLE
add support for browserstack mobile browser testing

### DIFF
--- a/shishito/conf/conftest.py
+++ b/shishito/conf/conftest.py
@@ -61,7 +61,7 @@ def pytest_addoption(parser):
                      help="BrowserStack mobile platform: MAC, ANDROID")
     parser.addoption("--xdevice", action="store", default="iPad Air",
                      help="BrowserStack mobile device: iPad Air, Samsung Galaxy S5 and others")
-    parser.addoption("--xdeviceOrientation", action="store", default="portrait",
+    parser.addoption("--deviceOrientation", action="store", default="portrait",
                      help="BrowserStack mobile device screen orientation: portrait or landscape")
     parser.addoption("--jira_support", action="store", default=None,
                      help="Jira username and password")
@@ -72,7 +72,10 @@ def pytest_addoption(parser):
     parser.addoption('--test_mobile', action="store", default=None,
                      help="Execute tests on mobile devices")
 
+
+
     # APPIUM
+
     parser.addoption('--platformName', action="store", default=None,
                      help="Appium platform: ios, android")
     parser.addoption('--platformVersion', action="store", default=None,
@@ -91,6 +94,14 @@ def pytest_addoption(parser):
                      help="Auto accepts alerts on iOS devices")
     parser.addoption("--saucelabs", action="store", default=None,
                      help="Saucelabs username and password")
+
+    # BROWSERSTACK MOBILE
+
+    parser.addoption('--platform', action="store", default=None,
+                     help="Appium platform: ios, android")
+    parser.addoption('--device', action="store", default=None,
+                     help="Device name (simulator or real device)")
+
 
 
     # REPORTS

--- a/shishito/runtime/environment/browserstack.py
+++ b/shishito/runtime/environment/browserstack.py
@@ -64,6 +64,7 @@ class ControlEnvironment(ShishitoEnvironment):
         :return: dict with arguments for pytest or None
         """
         test_platform = self.shishito_support.test_platform
+        arguments = {}
         if(test_platform == 'web'):
             browser = self.shishito_support.get_opt(config_section, 'browser')
             browser_version = self.shishito_support.get_opt(config_section, 'browser_version')
@@ -120,35 +121,31 @@ class ControlEnvironment(ShishitoEnvironment):
         """
         test_platform = self.shishito_support.test_platform
         get_opt = self.shishito_support.get_opt
+        capabilities = {
+            'acceptSslCerts': get_opt('accept_ssl_cert').lower() == 'false',
+            'browserstack.debug': get_opt('browserstack_debug').lower(),
+            'project': get_opt('project_name'),
+            'build': get_opt('build_name'),
+            'name': self.get_test_name() + time.strftime('_%Y-%m-%d'),
+            'browserstack.local': get_opt('browserstack_local') or False
+             }
         if(test_platform == 'web'):
-            return {
-                'acceptSslCerts': get_opt('accept_ssl_cert').lower() == 'false',
-                'browserstack.debug': get_opt('browserstack_debug').lower(),
-                'project': get_opt('project_name'),
-                'build': get_opt('build_name'),
+            special_capabilities = {
                 'os': get_opt(config_section, 'os'),
                 'os_version': get_opt(config_section, 'os_version'),
                 'browser': get_opt(config_section, 'browser'),
                 'browser_version': get_opt(config_section, 'browser_version'),
-                'resolution': get_opt(config_section, 'resolution'),
-                'name': self.get_test_name() + time.strftime('_%Y-%m-%d'),
-                'browserstack.local': get_opt('browserstack_local') or False,
-        }
+                'resolution': get_opt(config_section, 'resolution')
+            }
         if(test_platform == 'mobile'):
-            return {
-                'acceptSslCerts': get_opt('accept_ssl_cert').lower() == 'false',
-                'browserstack.debug': get_opt('browserstack_debug').lower(),
-                'project': get_opt('project_name'),
-                'build': get_opt('build_name'),
+            special_capabilities = {
                 'browser': get_opt(config_section, 'browser'),
                 'platform': get_opt(config_section, 'platform'),
                 'device': get_opt(config_section, 'device'),
-                'deviceOrientation': get_opt(config_section, 'deviceOrientation') or 'portrait',
-
-                'name': self.get_test_name() + time.strftime('_%Y-%m-%d'),
-                'browserstack.local': get_opt('browserstack_local') or False,
+                'deviceOrientation': get_opt(config_section, 'deviceOrientation') or 'portrait'
             }
 
+        return {**capabilities, **special_capabilities}
     # TODO will need to implement some edge cases from there (mobile emulation etc..)
     # def get_browser_profile(self, browser_type):
     # """ returns ChromeOptions or FirefoxProfile with default settings, based on browser """

--- a/shishito/runtime/environment/browserstack.py
+++ b/shishito/runtime/environment/browserstack.py
@@ -63,31 +63,54 @@ class ControlEnvironment(ShishitoEnvironment):
         :param config_section: section in platform/environment.properties config
         :return: dict with arguments for pytest or None
         """
-
-        browser = self.shishito_support.get_opt(config_section, 'browser')
-        browser_version = self.shishito_support.get_opt(config_section, 'browser_version')
-        os_type = self.shishito_support.get_opt(config_section, 'os')
-        os_version = self.shishito_support.get_opt(config_section, 'os_version')
-        resolution = self.shishito_support.get_opt(config_section, 'resolution')
-
-        test_result_prefix = '[%s, %s, %s, %s, %s]' % (
+        test_platform = self.shishito_support.test_platform
+        if(test_platform == 'web'):
+            browser = self.shishito_support.get_opt(config_section, 'browser')
+            browser_version = self.shishito_support.get_opt(config_section, 'browser_version')
+            os_type = self.shishito_support.get_opt(config_section, 'os')
+            os_version = self.shishito_support.get_opt(config_section, 'os_version')
+            resolution = self.shishito_support.get_opt(config_section, 'resolution')
+            test_result_prefix = '[%s, %s, %s, %s, %s]' % (
             browser, browser_version, os_type, os_version, resolution
-        )
+            )
 
-        # Add browserstack credentials
-        bs_auth = self.shishito_support.get_opt('browserstack')
+            # Add browserstack credentials
+            bs_auth = self.shishito_support.get_opt('browserstack')
 
-        # prepare pytest arguments into execution list
-        return {
-            '--junit-prefix=': '--junit-prefix=' + test_result_prefix,
-            '--html-prefix=': '--html-prefix=' + test_result_prefix,
-            '--browser=': '--browser=' + browser,
-            '--browser_version=': '--browser_version=' + browser_version,
-            '--os=': '--os=' + os_type,
-            '--os_version=': '--os_version=' + os_version,
-            '--resolution=': '--resolution=' + resolution,
-            '--browserstack=': '--browserstack=' + bs_auth,
-        }
+            # prepare pytest arguments into execution list
+            return {
+                '--junit-prefix=': '--junit-prefix=' + test_result_prefix,
+                '--html-prefix=': '--html-prefix=' + test_result_prefix,
+                '--browser=': '--browser=' + browser,
+                '--browser_version=': '--browser_version=' + browser_version,
+                '--os=': '--os=' + os_type,
+                '--os_version=': '--os_version=' + os_version,
+                '--resolution=': '--resolution=' + resolution,
+                '--browserstack=': '--browserstack=' + bs_auth
+                }
+        if(test_platform == 'mobile'):
+            browser = self.shishito_support.get_opt(config_section, 'browser')
+            platform = self.shishito_support.get_opt(config_section, 'platform')
+            device = self.shishito_support.get_opt(config_section, 'device')
+            deviceOrientation = self.shishito_support.get_opt(config_section, 'deviceOrientation') or 'portrait'
+
+            test_result_prefix = '[%s, %s, %s]' % (
+                browser, platform, device
+            )
+
+            # Add browserstack credentials
+            bs_auth = self.shishito_support.get_opt('browserstack')
+
+            # prepare pytest arguments into execution list
+            return {
+                '--junit-prefix=': '--junit-prefix=' + test_result_prefix,
+                '--html-prefix=': '--html-prefix=' + test_result_prefix,
+                '--browser=': '--browser=' + browser,
+                '--platform=': '--platform=' + platform,
+                '--device=': '--device=' + device,
+                '--deviceOrientation=': '--deviceOrientation=' + deviceOrientation,
+                '--browserstack=': '--browserstack=' + bs_auth
+            }
 
     def get_capabilities(self, config_section):
         """ Return dictionary of capabilities for specific config combination.
@@ -95,22 +118,36 @@ class ControlEnvironment(ShishitoEnvironment):
         :param str config_section: section in platform/environment.properties config
         :return: dict with capabilities
         """
-
+        test_platform = self.shishito_support.test_platform
         get_opt = self.shishito_support.get_opt
-
-        return {
-            'acceptSslCerts': get_opt('accept_ssl_cert').lower() == 'false',
-            'browserstack.debug': get_opt('browserstack_debug').lower(),
-            'project': get_opt('project_name'),
-            'build': get_opt('build_name'),
-            'os': get_opt(config_section, 'os'),
-            'os_version': get_opt(config_section, 'os_version'),
-            'browser': get_opt(config_section, 'browser'),
-            'browser_version': get_opt(config_section, 'browser_version'),
-            'resolution': get_opt(config_section, 'resolution'),
-            'name': self.get_test_name() + time.strftime('_%Y-%m-%d'),
-            'browserstack.local': get_opt('browserstack_local') or False,
+        if(test_platform == 'web'):
+            return {
+                'acceptSslCerts': get_opt('accept_ssl_cert').lower() == 'false',
+                'browserstack.debug': get_opt('browserstack_debug').lower(),
+                'project': get_opt('project_name'),
+                'build': get_opt('build_name'),
+                'os': get_opt(config_section, 'os'),
+                'os_version': get_opt(config_section, 'os_version'),
+                'browser': get_opt(config_section, 'browser'),
+                'browser_version': get_opt(config_section, 'browser_version'),
+                'resolution': get_opt(config_section, 'resolution'),
+                'name': self.get_test_name() + time.strftime('_%Y-%m-%d'),
+                'browserstack.local': get_opt('browserstack_local') or False,
         }
+        if(test_platform == 'mobile'):
+            return {
+                'acceptSslCerts': get_opt('accept_ssl_cert').lower() == 'false',
+                'browserstack.debug': get_opt('browserstack_debug').lower(),
+                'project': get_opt('project_name'),
+                'build': get_opt('build_name'),
+                'browser': get_opt(config_section, 'browser'),
+                'platform': get_opt(config_section, 'platform'),
+                'device': get_opt(config_section, 'device'),
+                'deviceOrientation': get_opt(config_section, 'deviceOrientation') or 'portrait',
+
+                'name': self.get_test_name() + time.strftime('_%Y-%m-%d'),
+                'browserstack.local': get_opt('browserstack_local') or False,
+            }
 
     # TODO will need to implement some edge cases from there (mobile emulation etc..)
     # def get_browser_profile(self, browser_type):

--- a/shishito/runtime/platform/mobile/control_execution.py
+++ b/shishito/runtime/platform/mobile/control_execution.py
@@ -10,8 +10,15 @@ class ControlExecution(ShishitoExecution):
         :param str config_section: section in platform/environment.properties config
         :return: str with test result prefix
         """
+        test_env = self.shishito_support.get_opt('test_environment')
+        if(test_env == 'browserstack'):
+            platform = self.shishito_support.get_opt(config_section, 'platform')
+            device = self.shishito_support.get_opt(config_section, 'device')
+            browser = self.shishito_support.get_opt(config_section, 'browser')
 
-        platform = self.shishito_support.get_opt(config_section, 'platformName')
-        platform_version = self.shishito_support.get_opt(config_section, 'platformVersion')
+            return '[%s, %s, %s, %s]' % (config_section, platform, device, browser)
+        if(test_env == 'appium'):
+            platform = self.shishito_support.get_opt(config_section, 'platformName')
+            platform_version = self.shishito_support.get_opt(config_section, 'platformVersion')
 
-        return '[%s, %s, %s]' % (config_section, platform, platform_version)
+            return '[%s, %s, %s]' % (config_section, platform, platform_version)

--- a/shishito/runtime/platform/mobile/control_test.py
+++ b/shishito/runtime/platform/mobile/control_test.py
@@ -7,5 +7,19 @@
 from shishito.runtime.platform.shishito_control_test import ShishitoControlTest
 
 
+
 class ControlTest(ShishitoControlTest):
     """ ControlTest for mobile platform """
+    def test_init(self, url):
+        """ Executed only once after browser starts.
+         Suitable for general pre-test logic that do not need to run before every individual test-case.
+
+        :param str url:
+        """
+        test_platform = self.shishito_support.test_platform
+        test_env = self.shishito_support.get_opt('test_environment')
+        if(test_env == 'browserstack' and test_platform == 'mobile'):
+            self.driver.get(url)
+            self.driver.implicitly_wait(int(self.shishito_support.get_opt('default_implicit_wait')))
+
+

--- a/shishito/runtime/platform/shishito_control_test.py
+++ b/shishito/runtime/platform/shishito_control_test.py
@@ -80,6 +80,3 @@ class ShishitoControlTest(object):
 
         :param str url:
         """
-        self.driver.get(url)
-        self.driver.implicitly_wait(int(self.shishito_support.get_opt('default_implicit_wait')))
-

--- a/shishito/runtime/platform/shishito_control_test.py
+++ b/shishito/runtime/platform/shishito_control_test.py
@@ -80,3 +80,6 @@ class ShishitoControlTest(object):
 
         :param str url:
         """
+        self.driver.get(url)
+        self.driver.implicitly_wait(int(self.shishito_support.get_opt('default_implicit_wait')))
+

--- a/shishito/runtime/platform/shishito_execution.py
+++ b/shishito/runtime/platform/shishito_execution.py
@@ -66,7 +66,6 @@ class ShishitoExecution(object):
             '--html-prefix=': '--html-prefix=' + test_result_prefix,
             '--instafail': '--instafail',
         }
-
         # extend pytest_arguments with environment specific args
         extra_pytest_arguments = self.environment.get_pytest_arguments(config_section)
         if extra_pytest_arguments:


### PR DESCRIPTION
Please look at this request, this my implemetation to use browserstack with mobile capabilities: 
https://www.browserstack.com/automate/python here you can see what capabilities required, now user can provide in test_platform=mobile and test_enviroment=browserstack values in config file. 