### PR TITLE
Enable experimental web platform features in Chrome

### DIFF
--- a/shishito/runtime/environment/shishito.py
+++ b/shishito/runtime/environment/shishito.py
@@ -85,6 +85,7 @@ class ShishitoEnvironment(object):
         if browser_type == 'chrome':
             chrome_options = webdriver.ChromeOptions()
             chrome_options.add_experimental_option("excludeSwitches", ["ignore-certificate-errors"])
+            chrome_options.add_argument('--enable-experimental-web-platform-features')
             capabilities.update(chrome_options.to_capabilities())
         elif browser_type == 'firefox':
             profile = webdriver.FirefoxProfile()


### PR DESCRIPTION
I added one option required for Huma testing.
Unfortunately I did not find a way of setting this option other than updating Shishito.

This option does not have any negative effects if enabled (no other tests should be impacted)