### PR TITLE
Indent JSON browser logs to be more readable by human

### DIFF
--- a/shishito/runtime/platform/shishito_control_test.py
+++ b/shishito/runtime/platform/shishito_control_test.py
@@ -72,7 +72,7 @@ class ShishitoControlTest(object):
                     os.makedirs(debugevent_folder)
 
                 with open(os.path.join(debugevent_folder, file_name + '.json'), 'w') as logfile:
-                        json.dump(debug_events, logfile)
+                        json.dump(debug_events, logfile, indent=4)
 
     def test_init(self, url):
         """ Executed only once after browser starts.


### PR DESCRIPTION
When logfile is big it is difficult to read it just by opening it - I suggest to indent JSON files to be readable also by humans :)