### PR TITLE
support testing mobile application using appium in Browserstack

### DIFF
--- a/shishito/conf/conftest.py
+++ b/shishito/conf/conftest.py
@@ -101,8 +101,8 @@ def pytest_addoption(parser):
                      help="Appium platform: ios, android")
     parser.addoption('--device', action="store", default=None,
                      help="Device name (simulator or real device)")
-
-
+    parser.addoption('--browserstack.appium_version', action="store", default=None,
+                     help="Appium default version")
 
     # REPORTS
     group = parser.getgroup("terminal reporting")

--- a/shishito/runtime/platform/mobile/control_execution.py
+++ b/shishito/runtime/platform/mobile/control_execution.py
@@ -22,3 +22,9 @@ class ControlExecution(ShishitoExecution):
             platform_version = self.shishito_support.get_opt(config_section, 'platformVersion')
 
             return '[%s, %s, %s]' % (config_section, platform, platform_version)
+
+        if (test_env == 'appium_bs'):
+            os_version = self.shishito_support.get_opt(config_section, 'os_version')
+            device = self.shishito_support.get_opt(config_section, 'device')
+            return '[%s, %s, %s]' % (config_section, os_version, device)
+

--- a/shishito/runtime/platform/shishito_control_test.py
+++ b/shishito/runtime/platform/shishito_control_test.py
@@ -36,7 +36,8 @@ class ShishitoControlTest(object):
 
         if base_url:
             self.test_init(driver, base_url)
-
+        else:
+            self.test_init(driver)
         return driver
 
     def start_test(self, reload_page=None):
@@ -65,6 +66,8 @@ class ShishitoControlTest(object):
             # Capture screenshot and debug info from driver(s)
             for driver in self.drivers:
                 browser_name = driver.name
+                if browser_name == '':
+                    browser_name = 'appium'
                 file_name = browser_name + '_' + test_name
 
                 ts = SeleniumTest(driver)
@@ -81,7 +84,7 @@ class ShishitoControlTest(object):
                     with open(os.path.join(debugevent_folder, file_name + '.json'), 'w') as logfile:
                             json.dump(debug_events, logfile)
 
-    def test_init(self, driver, url):
+    def test_init(self, driver, url=None):
         """ Executed only once after browser starts.
          Suitable for general pre-test logic that do not need to run before every individual test-case.
 


### PR DESCRIPTION
Add support for using appium in BrowserStack, for testing mobile app new configuration parameter is added: appium_bs
For running tests: file named **appium_bs.properties** under **mobile** folder should be presented, example of **appium_bs.properties**:
[iOSApp]
os_version=10.2
device=iPhone 7
browserstack.appium_version=
app=<path to app in Browserstack>
autoAcceptAlerts=True

In server.properties config values should be:
test_platform=mobile
test_environment=appium_bs
