### PR TITLE
Still check requirements.txt even if venv exists

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,8 @@
 # History
+
+## 3.1.9 (2019-07-18)
+* Minor fix of `shi` script not updating newly added packages to requirements.txt
+
 ## 3.1.8 (2019-07-03)
 * Fix of HTML Test Report not showing errors in the setup phase
 * Disable escaping of special characters error message in Test Report

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools.command.install import install
 import os
 import sys
 
-VERSION = '3.1.8'
+VERSION = '3.1.9'
 
 with open('README.md', encoding='utf-8') as readme_file:
     readme = readme_file.read()

--- a/shi
+++ b/shi
@@ -28,7 +28,7 @@ else
   . "$VIRTUAL_ENV/bin/activate"
   if [[ -f "$SCRIPT_DIR/requirements.txt" ]] ; then
     echo "Checking for newly added requirements"
-    pip3 install -r requirements.txt
+    pip3 install -r "$SCRIPT_DIR/requirements.txt"
   fi
 fi
 

--- a/shi
+++ b/shi
@@ -24,6 +24,12 @@ if ! [ -d "$VIRTUAL_ENV" ]; then
   else
     echo "File requirements.txt not found, not installing requirements"
   fi
+else
+  . "$VIRTUAL_ENV/bin/activate"
+  if [[ -f "$SCRIPT_DIR/requirements.txt" ]] ; then
+    echo "Checking for newly added requirements"
+    pip3 install -r requirements.txt
+  fi
 fi
 
 if [[ ! -f 'config/local_config.properties' ]] ; then


### PR DESCRIPTION
There is an issue when running tests from command line using the `shi` script.

At first run it creates the `/venv` and install every package from `requirements.txt` correctly.
If requirements are modified (new items added), they are not added to the `/venv` automatically.